### PR TITLE
Fix: Inherited TextEntry metadata not rendering due to missing entry-wrapper

### DIFF
--- a/resources/views/components/maskable-entry.blade.php
+++ b/resources/views/components/maskable-entry.blade.php
@@ -1,12 +1,14 @@
-<div>
-    <div class="text-sm font-medium text-black-500">{{ $getLabel() }}</div>
-    <div x-data="{ show: false }" class="flex items-center gap-2 mt-1">
-        <span x-text="show ? '{{ $getFormattedValue() }}' : '{{ $getMaskedValue() }}'"></span>
-        @if ($getFormattedValue() !== 'N/A')
-            <button type="button" x-on:click="show = !show" class="text-black-100 hover:text-black-100">
-                <x-filament::icon icon="heroicon-o-eye" x-show="!show" class="w-5 h-5" />
-                <x-filament::icon icon="heroicon-o-eye-slash" x-show="show" class="w-5 h-5" />
-            </button>
-        @endif
+<x-filament-infolists::entry-wrapper :entry="$entry">
+    <div>
+        <div class="text-sm font-medium text-black-500">{{ $getLabel() }}</div>
+        <div x-data="{ show: false }" class="flex items-center gap-2 mt-1">
+            <span x-text="show ? '{{ $getFormattedValue() }}' : '{{ $getMaskedValue() }}'"></span>
+            @if ($getFormattedValue() !== 'N/A')
+                <button type="button" x-on:click="show = !show" class="text-black-100 hover:text-black-100">
+                    <x-filament::icon icon="heroicon-o-eye" x-show="!show" class="w-5 h-5" />
+                    <x-filament::icon icon="heroicon-o-eye-slash" x-show="show" class="w-5 h-5" />
+                </button>
+            @endif
+        </div>
     </div>
-</div>
+</x-filament-infolists::entry-wrapper>


### PR DESCRIPTION
This pull request fixes an issue where standard Filament Infolist metadata methods, such as `->hint()`, `->hintIcon()`, and custom styling applied via `->extraAttributes()`, were not rendering correctly on the `MaskableEntry` component.

The issue was caused by the custom Blade view overriding the standard Filament entry rendering structure.

**Solution:**

The fix involves wrapping the component's custom logic in the standard Filament Infolists component wrapper: `<x-filament-infolists::entry-wrapper :entry="$entry">`.

This ensures that the component's label, hints, and other inherited visual features are handled by Filament's core rendering system, while keeping the custom Alpine.js masking logic intact.